### PR TITLE
Add lastPage to pagination state

### DIFF
--- a/src/directives/pagination.ts
+++ b/src/directives/pagination.ts
@@ -40,6 +40,7 @@ export interface PaginationDirectiveConfiguration<T> {
 export const paginationDirective = <T>({table}: PaginationDirectiveConfiguration<T>): PaginationDirective => {
     let {slice: {page: currentPage, size: currentSize}} = table.getTableState();
     let itemListLength = table.filteredCount;
+    let lastPage = Math.ceil(itemListLength / currentSize);
 
     const proxy = <PaginationProxy>sliceListener({emitter: table});
 
@@ -60,10 +61,10 @@ export const paginationDirective = <T>({table}: PaginationDirectiveConfiguration
             return currentPage > 1;
         },
         isNextPageEnabled() {
-            return Math.ceil(itemListLength / currentSize) > currentPage;
+            return lastPage > currentPage;
         },
         state() {
-            return Object.assign(table.getTableState().slice, {filteredCount: itemListLength});
+            return Object.assign(table.getTableState().slice, {filteredCount: itemListLength, lastPage});
         }
     };
     const directive = Object.assign(api, proxy);
@@ -72,6 +73,7 @@ export const paginationDirective = <T>({table}: PaginationDirectiveConfiguration
         currentPage = p;
         currentSize = s;
         itemListLength = filteredCount;
+        lastPage = Math.ceil(itemListLength / currentSize);
     });
 
     return directive;

--- a/test/directives/pagination.js
+++ b/test/directives/pagination.js
@@ -74,5 +74,5 @@ test('pagination directive should return the pagination part of the table state 
     const table = fakeTable({size: 25, page: 3, filteredCount: 100});
     const dir = pagination({table});
     table.dispatch(evts.SUMMARY_CHANGED, {size: 25, page: 3, filteredCount: 100});
-    t.deepEqual(dir.state(), {size: 25, page: 3, filteredCount: 100});
+    t.deepEqual(dir.state(), {size: 25, page: 3, filteredCount: 100, lastPage: 4});
 });


### PR DESCRIPTION
This is convenient when displaying the last page of the table and using `selectPage(lastPage)` to navigate to the last page of the table. 