### PR TITLE
Avoid divide-by-zero for pageCount

### DIFF
--- a/src/directives/pagination.ts
+++ b/src/directives/pagination.ts
@@ -40,7 +40,7 @@ export interface PaginationDirectiveConfiguration<T> {
 export const paginationDirective = <T>({table}: PaginationDirectiveConfiguration<T>): PaginationDirective => {
     let {slice: {page: currentPage, size: currentSize}} = table.getTableState();
     let itemListLength = table.filteredCount;
-    let pageCount = Math.ceil(itemListLength / currentSize);
+    let pageCount = currentSize ? Math.ceil(itemListLength / currentSize) : 1;
 
     const proxy = <PaginationProxy>sliceListener({emitter: table});
 
@@ -73,7 +73,7 @@ export const paginationDirective = <T>({table}: PaginationDirectiveConfiguration
         currentPage = p;
         currentSize = s;
         itemListLength = filteredCount;
-        pageCount = Math.ceil(itemListLength / currentSize);
+        pageCount = currentSize ? Math.ceil(itemListLength / currentSize) : 1;
     });
 
     return directive;

--- a/test/directives/pagination.js
+++ b/test/directives/pagination.js
@@ -76,3 +76,10 @@ test('pagination directive should return the pagination part of the table state 
     table.dispatch(evts.SUMMARY_CHANGED, {size: 25, page: 3, filteredCount: 100});
     t.deepEqual(dir.state(), {size: 25, page: 3, filteredCount: 100, pageCount: 4});
 });
+test('pagination directive accepts falsy value for page size', t => {
+    const table = fakeTable({page: 1});
+    const dir = pagination({table});
+    t.deepEqual(dir.state().pageCount, 1);
+    table.dispatch(evts.SUMMARY_CHANGED, {page: 1, size: 0});
+    t.deepEqual(dir.state().pageCount, 1);
+});


### PR DESCRIPTION
https://github.com/smart-table/smart-table-core/commit/ce0a529462c9d4faea547bbfb44b69bd83172def#diff-0e3ca84b8669dadd527983881dc68e6aR2 allows page size to be undefined so that the table will have 1 page only. Got bitten by this bug today when changing the page size.

This patch assumes that there is an implicit `page >= 1` assertion such that `pageCount >= 1` is always true.